### PR TITLE
ar71xx: fix regression in 74x164 initialization with 4.9

### DIFF
--- a/target/linux/ar71xx/patches-4.9/451-gpio-74x164-improve-platform-device-support.patch
+++ b/target/linux/ar71xx/patches-4.9/451-gpio-74x164-improve-platform-device-support.patch
@@ -25,7 +25,7 @@
  	/*
  	 * bits_per_word cannot be configured in platform data
  	 */
-@@ -115,17 +123,23 @@ static int gen_74x164_probe(struct spi_d
+@@ -115,12 +123,15 @@ static int gen_74x164_probe(struct spi_d
  	if (ret < 0)
  		return ret;
  
@@ -47,15 +47,7 @@
  
  	chip = devm_kzalloc(&spi->dev, sizeof(*chip) + nregs, GFP_KERNEL);
  	if (!chip)
- 		return -ENOMEM;
- 
-+	if (pdata && pdata->init_data)
-+		memcpy(chip->buffer, pdata->init_data, chip->registers);
-+	
- 	spi_set_drvdata(spi, chip);
- 
- 	chip->gpio_chip.label = spi->modalias;
-@@ -133,7 +147,11 @@ static int gen_74x164_probe(struct spi_d
+@@ -133,7 +144,11 @@ static int gen_74x164_probe(struct spi_d
  	chip->gpio_chip.get = gen_74x164_get_value;
  	chip->gpio_chip.set = gen_74x164_set_value;
  	chip->gpio_chip.set_multiple = gen_74x164_set_multiple;
@@ -68,6 +60,16 @@
  
  	chip->registers = nregs;
  	chip->gpio_chip.ngpio = GEN_74X164_NUMBER_GPIOS * chip->registers;
+@@ -142,6 +157,9 @@ static int gen_74x164_probe(struct spi_d
+ 	chip->gpio_chip.parent = &spi->dev;
+ 	chip->gpio_chip.owner = THIS_MODULE;
+ 
++	if (pdata && pdata->init_data)
++		memcpy(chip->buffer, pdata->init_data, chip->registers);
++
+ 	mutex_init(&chip->lock);
+ 
+ 	ret = __gen_74x164_write_config(chip);
 @@ -170,17 +188,19 @@ static int gen_74x164_remove(struct spi_
  	return 0;
  }


### PR DESCRIPTION
The memcpy of the init data relies on chip->registers to be initialized,
which only happens later in the code. Move this initialization further
down to make it work.
This was breaking PCIe/USB on some MikroTik RouterBoard devices.

Signed-off-by: Felix Fietkau <nbd@nbd.name>

Thanks for your contribution to the LEDE project!

To help keep the codebase consistent and readable,
and to help people review your contribution,
we ask you to follow the rules you find in the wiki at this link
https://lede-project.org/submitting-patches

Please remove this message before posting the pull request.
